### PR TITLE
fix: sort users just by last_login

### DIFF
--- a/game/admin.py
+++ b/game/admin.py
@@ -94,7 +94,7 @@ class AppUserAdmin(UserAdmin):
         "date_joined",
     )
     ordering = (
-        "-last_login__day",
+        "-last_login",
         "-date_joined",
     )
     list_filter = (StaffFilter, HasPlayedFilter, "notifications_status")


### PR DESCRIPTION
last_login_day ignores months